### PR TITLE
minor naming/snytax issues corrected for part schema/route

### DIFF
--- a/src/model/part.js
+++ b/src/model/part.js
@@ -6,7 +6,7 @@ const SubAssembly = require('./sub-assembly');
 
 const partSchema = mongoose.Schema({
   partId: {
-    type: Number,
+    type: String,
     unique: true,
     required: true,
   },

--- a/src/routes/part-routes.js
+++ b/src/routes/part-routes.js
@@ -16,14 +16,26 @@ router.post('/parts', jsonParser, (request, response, next) => {
     logger.log(logger.INFO, '400 | invalid request');
     return response.sendStatus(400);
   }
-  if (!request.body.subId) {
-    return Part.create(request.body)
+  if (!request.body.subIDRef) {
+    return Part.create(
+      request.body.partId,
+      request.body.partDescription,
+      request.body.partSub,
+      request.body.partSrc,
+      request.body.partMfgNum,
+      request.body.partPrice,
+      request.body.partCategory,
+      request.body.partLocation,
+      request.body.partCount,
+      request.body.partLongLead,
+      request.body.partNotes,
+    )
       .then((part) => {
         logger.log(logger.INFO, 'SUCCESS - Creating Standalone Part', part);
         return response.json({ part });
       })
       .catch(next);
-  }
+  } // else ... if subIDRef is not blank
   return new Part(request.body).save()
     .then((part) => {
       logger.log(logger.INFO, 'Responding with a 200 status code');


### PR DESCRIPTION
@tnorth93 

Plopping the request.body into the .create was not working for the web call. I just updated it so that it mimicked the format of our sub assembly creation. Also, it's hard to see, but on line 19 in part-routes `subID` needed to be `subIDRef`. The subIDRef in the front end is what controls the objectID linking on the back-end.

Ben