### PR TITLE
updated logo query to return base64 string to front-end

### DIFF
--- a/src/routes/logo-query.js
+++ b/src/routes/logo-query.js
@@ -32,7 +32,9 @@ router.get('/company-logo', jsonParser, (request, response, next) => { //eslint-
       } // else
       return undefined;
     });
-    return response.json({ imageToReturn });
+    // we can render base64 strings as <img> tags in React :)
+    const convertToBase64 = Buffer.from(imageToReturn[0].buffer).toString('base64');
+    return response.json({ base64: convertToBase64 });
   });
   // needs additional error handling but commit this base query for now
 });

--- a/src/routes/logo-query.js
+++ b/src/routes/logo-query.js
@@ -27,7 +27,7 @@ router.get('/company-logo', jsonParser, (request, response, next) => { //eslint-
   // return all logos in db
   let query = runLogoQuery((callback, error) => { //eslint-disable-line
     const imageToReturn = callback.filter((image) => {
-      if (image.originalname === 'company-logo.jpg' || image.originalname === 'company-logo.jpeg' || image.originalname === 'company-logo.png') {
+      if (image.originalname === 'company-logo') {
         return image;
       } // else
       return undefined;

--- a/src/routes/logoUploadRoute.js
+++ b/src/routes/logoUploadRoute.js
@@ -15,35 +15,58 @@ const router = module.exports = new express.Router();
 
 // ROUTE(S)
 router.post('/company-logo/upload', upload.single('image'), (request, response, next) => {
-  // this route needs better error handling
   console.log('request.file');
   console.log(request.file);
+  const originalNameStripped = request.file.originalname.split('.')[0];
+
+  if (originalNameStripped !== 'company-logo') {
+    logger.log(logger.INFO, '400 | logo must be named: company-logo');
+    return response.sendStatus(400);
+  }
+
   if (request.file.mimetype !== 'image/png' && request.file.mimetype !== 'image/jpeg') {
     // not perfect, but helps to disallow incorrect file types
     // currently we accept png's and jpeg's
     logger.log(logger.INFO, '400 | incorrect mimetype');
     return response.sendStatus(400);
   }
+
+  // once the mimetype is verified, save the originalname without file extension
+  // this makes it easier to replace all files named company logo
+  // currently, only 1 company logo will be allowed and replaced if re-uploaded
+  request.file.originalname = originalNameStripped;
+
   const {
     buffer, mimetype, originalname, encoding,
   } = request.file; // eslint-disable-line prefer-const
 
+  const incomingImage = {
+    buffer, mimetype, originalname, encoding, 
+  };
+  
+  const query = { originalname };
+
   // for now, also write file to local FS to test buffer stream
   // this can be eventually removed but good for now
-  fs.writeFile('./uploads/company-logo.png', buffer, function(err) {
+  fs.writeFile('./uploads/company-logo.png', buffer, (err) => {
     if (err) {
       return console.log(err);
     }
     console.log(`${originalname} saved - local dir ../../uploads/`);
   });
 
-  return CompanyLogo.create(
-    buffer,
-    mimetype,
-    originalname,
-    encoding,
-  ).then((logo) => {
-    logger.log(logger.INFO, '200 - image saved');
-    response.json(logo);
-  }).catch(error => next(error));
+  // { upsert: true } allows us to create the intial entry if it does not already exist
+  // otherwise, image being sent will just be replaced
+  // currently, this reduces complexity of managing multiple logos in the front-end
+  // we can re-visit in future if needed
+  // not using promise with this query or it causes double entries to be created
+  return CompanyLogo.findOneAndUpdate(query, incomingImage, { upsert: true }, (err, doc) => { // eslint-disable-line
+    if (err) {
+      return response.send(500, { error: err });
+    }
+    if (doc) {
+      logger.log(logger.INFO, '200 - image saved');
+      return response.json(doc);
+    }
+  });
 });


### PR DESCRIPTION
@tnorth93 

This back-end PR goes hand and hand with:
https://github.com/lets-go-geronimo/readyIMS-front-end/pull/11

I'm going to try and start linking each repos PRs when they are front/back-end ^

This is an adjustment to the back-end to hand the front-end a ready to go base64 string. This is taken from the inMemory image stream, sent to the DB and stored as a Buffer, then called out again during the query and converted to a base64 string. React can use this to render a straight <img> tag. Super cool beans.

Ben