### PR TITLE
testing token handling / account return

### DIFF
--- a/src/model/account.js
+++ b/src/model/account.js
@@ -41,9 +41,18 @@ function pCreateToken() {
   this.tokenSeed = crypto.randomBytes(TOKEN_SEED_LENGTH).toString('hex');
   return this.save()
     .then((account) => {
-      return jsonWebToken.sign({
-        tokenSeed: account.tokenSeed,
+      const handOff = {};
+      handOff.tokenSeed = account.tokenSeed;
+      handOff.isAdmin = account.isAdmin;
+      return handOff;
+    })
+    .then((parsedAccount) => {
+      const objectToSend = {};
+      objectToSend.tokenSeed = jsonWebToken.sign({
+        tokenSeed: parsedAccount.tokenSeed,
       }, process.env.APP_SECRET);
+      objectToSend.isAdmin = parsedAccount.isAdmin;
+      return objectToSend;
     })
     .catch((error) => {
       throw error;

--- a/src/routes/authRouter.js
+++ b/src/routes/authRouter.js
@@ -46,9 +46,13 @@ router.get('/login', basicAuthMiddleware, (request, response, next) => {
     return next(new HttpError(401, 'AUTH | invalid request'));
   }
   return request.account.pCreateToken()
-    .then((token) => {
+    .then((toReturn) => {
+      console.log('toReturn:');
+      console.log(toReturn);
+      const token = toReturn.tokenSeed;
+      const isAdmin = toReturn.isAdmin; // eslint-disable-line prefer-destructuring
       logger.log(logger.INFO, 'Responding with a 200 status code and a TOKEN');
-      return response.json({ token });
+      return response.json({ token, isAdmin });
     })
     .catch(next);
 });


### PR DESCRIPTION
@tnorth93 @jlhiskey 

I plan to branch off this branch before it is merged to continue with updates. The changes in here were just testing and will likely not stick. Do not merge this until I can follow up with the next PR.

Today what I discovered is that we need to refactor how the back-end is handling token refresh and in turn refactor how the front-end is calling for it.

Currently, the cookie check on every store fresh is not going to fly. Tomorrow morning, I plan to implement a bearer-auth route to handle token checking/refresh and this will also allow us to cleanly hand off isAdmin property for setting menu rendering as well as account creation. Allowing us to get this property from the DB will give admins more control and users just what they need.

Ben