### PR TITLE
new route for bearer auth / token refresh

### DIFF
--- a/src/lib/bearerAuthMiddleware.js
+++ b/src/lib/bearerAuthMiddleware.js
@@ -16,6 +16,9 @@ const promisify = curryFunction => (...args) => {
 };
 
 module.exports = (request, response, next) => {
+  // uncomment for debugging
+  // console.log('BACK-END REQUEST');
+  // console.log(request.headers);
   if (!request.headers.authorization) {
     return next(new HttpError(400, 'AUTH | invalid request'));
   }

--- a/src/routes/authRouter.js
+++ b/src/routes/authRouter.js
@@ -5,6 +5,7 @@ const bodyParser = require('body-parser');
 const HttpError = require('http-errors');
 
 const basicAuthMiddleware = require('../lib/basicAuthMiddleware');
+const bearerAuthMiddleware = require('../lib/bearerAuthMiddleware');
 const Account = require('../model/account');
 const logger = require('../lib/logger');
 
@@ -47,8 +48,23 @@ router.get('/login', basicAuthMiddleware, (request, response, next) => {
   }
   return request.account.pCreateToken()
     .then((toReturn) => {
-      console.log('toReturn:');
-      console.log(toReturn);
+      const token = toReturn.tokenSeed;
+      const isAdmin = toReturn.isAdmin; // eslint-disable-line prefer-destructuring
+      logger.log(logger.INFO, 'Responding with a 200 status code and a TOKEN');
+      return response.json({ token, isAdmin });
+    })
+    .catch(next);
+});
+
+// ==================================================================
+// token auth
+// ==================================================================
+router.get('/token-auth', bearerAuthMiddleware, (request, response, next) => {
+  if (!request.account) {
+    return next(new HttpError(401, 'AUTH | invalid request'));
+  }
+  return request.account.pCreateToken()
+    .then((toReturn) => {
       const token = toReturn.tokenSeed;
       const isAdmin = toReturn.isAdmin; // eslint-disable-line prefer-destructuring
       logger.log(logger.INFO, 'Responding with a 200 status code and a TOKEN');


### PR DESCRIPTION
@tnorth93 @jlhiskey 

Git recognized the deltas here in an odd way. Because the code is almost identical to the login route, it's not showing the green over the last route and only part of it.

This new route handles the token refresh. This is needed in order to continually validate our users. 

Chain of events:
- redux store state gets triggered either by a page reload, login, and or signup
- upon state change, redux fires off it's action/reducers
- the code in the front-end 'token' reducer gets called to find the cookie with the old token string
- the old token string gets sent to the back-end '/token-auth' for bearerAuthMiddleware validation
- if the string matches, the account information is re-sent with a fresh token that updates the redux store state and the cookie

As long as the user is refreshing every 4 hours their cookie will not expire. 

The current bugs with this now are not effectively the application state/cookies, but some weird artifact object properties are appearing in the redux store. I think it has to do with async and I'll do my best to detail that out in the front-end PR next.

Ben